### PR TITLE
Also push images to quay.io

### DIFF
--- a/.github/workflows/someip_provider.yml
+++ b/.github/workflows/someip_provider.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to the Container registry
+      - name: Log in to ghcr.io container registry
         uses: docker/login-action@v3
         if: needs.check_ghcr_push.outputs.push == 'true'
         with:
@@ -113,12 +113,21 @@ jobs:
             username: ${{ github.repository_owner }}
             password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log in to quay.io container registry
+        if: needs.check_ghcr_push.outputs.push == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_IO_USERNAME }}
+          password: ${{ secrets.QUAY_IO_TOKEN }}
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
             ghcr.io/${{ github.repository }}/someip-provider
+            quay.io/eclipse-kuksa/someip-provider
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -126,7 +135,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
 
-      - name: "Build someip2val container and push to ghcr.io"
+      - name: "Build someip2val container and push to ghcr.io, quay.io and ttl.sh"
         if: needs.check_ghcr_push.outputs.push == 'true'
         id: image_build_ghcr
         uses: docker/build-push-action@v5
@@ -139,7 +148,6 @@ jobs:
           tags: |
             ${{ steps.meta.outputs.tags }}
             ttl.sh/eclipse-kuksa/kuksa-someip-provider/someip-provider-${{github.sha}}
-            ttl.sh/kuksa.val.feeders/someip-feeder-${{github.sha}}
           labels: ${{ steps.meta.outputs.labels }}
           # Provenance to solve that an unknown/unkown image is shown on ghcr.io
           # Same problem as described in https://github.com/orgs/community/discussions/45969


### PR DESCRIPTION
Does for someip-provider what https://github.com/eclipse-kuksa/kuksa-databroker/issues/36 did for databroker

@erikbosch  In this repo only did the Action modifications. Even the ghcr image is never mentioned, and there is a lot of (outdated?) infos and scripts regarding containers, some referencing old repo or even some boschglobal forks.

Not good, but nothing I want to fix in this PR. For now, this should just sync the ghcr container state with quay.io